### PR TITLE
- added docstrings to all methods

### DIFF
--- a/src/VisPyStack.py
+++ b/src/VisPyStack.py
@@ -42,7 +42,7 @@ class Canvas(scene.SceneCanvas):
 
         """
         #initialize particle system
-        self.part_sys = ParticleSystem(self.native.width(), self.native.height(), color_distribution, interaction_matrix, radius=1)
+        self.part_sys = ParticleSystem(self.native.width(), self.native.height(), color_distribution, interaction_matrix, radius=1, delta_t = self.update_interval)
         
         #extract particle system attributes
         self.positions = self.part_sys.positions


### PR DESCRIPTION
- changed mistake in init particles that was never found in runtime because move particles always np.mod the positions. Positions were set only based on self.width which could cause out of bounds errors in spatial tree. Corrected this mistake now
- fixed mistake in VisPyStack where the particle system was not intialized with the same framerate as the GUI
- adjusted min and max velocities according to new (slower) speeds due to changed refresh rate in backend